### PR TITLE
Typo fix

### DIFF
--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -18,7 +18,7 @@
                 <item
                     android:id="@+id/nav_3days"
                     android:icon="@drawable/ic_view_week"
-                    android:title="3-day" />
+                    android:title="3 Day" />
                 <item
                     android:id="@+id/nav_week"
                     android:icon="@drawable/ic_view_week"


### PR DESCRIPTION
3-day --> 3 Day

This mirrors the spelling of Google Calendar, and in extension that of regular English.
